### PR TITLE
Bug: multiple grid parameters and nest matching

### DIFF
--- a/griddler/griddle.py
+++ b/griddler/griddle.py
@@ -52,42 +52,44 @@ def parse(griddle: dict) -> list[dict]:
 
     # find where nested values will get merged, if they are present
     if "nested_parameters" in griddle:
-        ps_nest_map = {
-            _match_nest(nest, parameter_sets): nest
-            for nest in griddle["nested_parameters"]
-        }
+        ps_nests = [
+            _match_ps_nest(ps, griddle["nested_parameters"]) for ps in parameter_sets
+        ]
     else:
-        ps_nest_map = {}
+        ps_nests = [None for ps in parameter_sets]
 
     # merge in baseline values, if present
     if "baseline_parameters" in griddle:
         parameter_sets = [ps | griddle["baseline_parameters"] for ps in parameter_sets]
 
     # update the nested values, if nests were present
-    for ps_i, nest in ps_nest_map.items():
-        parameter_sets[ps_i] |= nest
+    for ps, nest in zip(parameter_sets, ps_nests):
+        if nest is not None:
+            ps |= nest
 
     return parameter_sets
 
 
-def _match_nest(nest, parameter_sets):
-    """Which parameter set does this nest match to?"""
-    matches = [_match_nest1(nest, ps) for ps in parameter_sets]
+def _match_ps_nest(parameter_set, nests):
+    """Which nest goes with this parameter set?"""
+    matches = [_match_ps_nest1(parameter_set, nest) for nest in nests]
     n_matches = matches.count(True)
     if n_matches == 0:
         return None
     if n_matches == 1:
-        return matches.index(True)
+        return nests[matches.index(True)]
     else:
-        raise RuntimeError(f"Nest {nest} matches multiple of {parameter_sets}")
+        raise RuntimeError(
+            f"Parameter set {parameter_set} matches multiple nests: {matches}"
+        )
 
 
-def _match_nest1(nest, parameter_set):
-    """Does this nest match this parameter set?"""
-    common_keys = nest.keys() & parameter_set.keys()
-    nest_subset = {key: nest[key] for key in common_keys}
-    parameter_subset = {key: parameter_set[key] for key in common_keys}
-    return nest_subset == parameter_subset
+def _match_ps_nest1(parameter_set, nest):
+    """Does this parameter_set match this nest?"""
+    # parameter names in common to both the ps and the nest
+    common_keys = parameter_set.keys() & nest.keys()
+    # are the values the same, in the ps and nest, for those common names?
+    return all(nest[key] == parameter_set[key] for key in common_keys)
 
 
 def read(path: str) -> list[dict]:

--- a/tests/test_griddle.py
+++ b/tests/test_griddle.py
@@ -59,3 +59,27 @@ def test_baseline_grid_nested():
         {"scenario": "optimistic", "R0": 0.5},
         {"scenario": "pessimistic", "R0": 2.0},
     ]
+
+
+def test_multiple_grid_nested():
+    griddle = yaml.safe_load("""
+    grid_parameters:
+      scenario: [baseline, optimistic, pessimistic]
+      gamma: [0.1, 0.2]
+
+    nested_parameters:
+      - scenario: optimistic
+        R0: 0.5
+      - scenario: pessimistic
+        R0: 2.0
+    """)
+
+    parameter_sets = parse(griddle)
+    assert parameter_sets == [
+        {"scenario": "baseline", "R0": 1.0, "gamma": 0.1},
+        {"scenario": "baseline", "R0": 1.0, "gamma": 0.2},
+        {"scenario": "optimistic", "R0": 0.5, "gamma": 0.1},
+        {"scenario": "optimistic", "R0": 0.5, "gamma": 0.2},
+        {"scenario": "pessimistic", "R0": 2.0, "gamma": 0.1},
+        {"scenario": "pessimistic", "R0": 2.0, "gamma": 0.2},
+    ]

--- a/tests/test_griddle.py
+++ b/tests/test_griddle.py
@@ -1,4 +1,4 @@
-from griddler.griddle import parse, _match_nest
+from griddler.griddle import parse, _match_ps_nest
 import yaml
 
 
@@ -29,13 +29,13 @@ def test_grid_only():
 
 
 def test_match_nest():
-    assert (
-        _match_nest(
-            nest={"scenario": "optimistic", "R0": 0.5},
-            parameter_sets=[{"scenario": "optimistic"}, {"scenario": "pessimistic"}],
-        )
-        == 0
-    )
+    assert _match_ps_nest(
+        parameter_set={"scenario": "optimistic"},
+        nests=[
+            {"scenario": "optimistic", "R0": 0.5},
+            {"scenario": "pessimistic", "R0": 1.5},
+        ],
+    ) == {"scenario": "optimistic", "R0": 0.5}
 
 
 def test_baseline_grid_nested():
@@ -63,6 +63,9 @@ def test_baseline_grid_nested():
 
 def test_multiple_grid_nested():
     griddle = yaml.safe_load("""
+    baseline_parameters:
+      R0: 1.0
+
     grid_parameters:
       scenario: [baseline, optimistic, pessimistic]
       gamma: [0.1, 0.2]


### PR DESCRIPTION
Old behavior was to check that each nest would match zero or one grid parameter set. This is backwards: each parameter set should match zero or one nests.