### PR TITLE
Support dictionaries of dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ See the [GitHub pages documentation](https://cdcgov.github.io/pygriddler/) for m
 
 Scott Olesen <ulp7@cdc.gov> (CDC/IOD/ORR/CFA)
 
+## Changelog
+
+- v0.2.0: Add support for dictionary-of-dictionary parameters
+
 ---
 
 ## General Disclaimer

--- a/docs/griddle.md
+++ b/docs/griddle.md
@@ -8,7 +8,10 @@
   - It must not have any other keys.
 - `baseline_parameters` is a dictionary.
   - The keys are parameter names; the values are parameter values.
-  - A parameter value is valid if it is an integer, float, or string, or if it a string made up of valid values.
+  - A parameter value is valid if it is:
+    - an integer, float, or string,
+    - a list or tuple made up of integers, floats, or strings, or
+    - a dictionary whose keys are strings and whose values are any valid parameter (i.e., scalar, list, or another valid dictionary).
 - `grid_parameters` is a dictionary.
   - The keys are parameter names. Each value is a list. The elements in that list are the parameter values gridded over.
   - No keys can be repeated between `baseline_parameters` and `grid_parameters`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "griddler"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = ["Scott Olesen <ulp7@cdc.gov>"]
 readme = "README.md"

--- a/tests/test_griddle.py
+++ b/tests/test_griddle.py
@@ -1,5 +1,6 @@
-from griddler.griddle import parse, _match_ps_nest
 import yaml
+
+from griddler.griddle import _match_ps_nest, parse
 
 
 def test_baseline_only():
@@ -86,3 +87,16 @@ def test_multiple_grid_nested():
         {"scenario": "pessimistic", "R0": 2.0, "gamma": 0.1},
         {"scenario": "pessimistic", "R0": 2.0, "gamma": 0.2},
     ]
+
+
+def test_nested_dicts():
+    griddle = yaml.safe_load("""
+    baseline_parameters:
+      random_numbers:
+        distribution: gamma
+        shape: 1.0
+        scale: 0.5
+    """)
+
+    parameter_sets = parse(griddle)
+    assert parameter_sets == [griddle["baseline_parameters"]]

--- a/tests/test_parameter_set.py
+++ b/tests/test_parameter_set.py
@@ -1,5 +1,6 @@
-from griddler import ParameterSet
 import pytest
+
+from griddler import ParameterSet
 
 
 def test_validate_keys():
@@ -8,10 +9,14 @@ def test_validate_keys():
         ParameterSet({1: 2})
 
 
-def test_validate_values_no_dict():
-    """Value can't be a dict"""
+def test_validate_values_dict():
+    """Value can be a dict, but sub-dicts must work"""
+    ParameterSet({"param": {"sub_param": "value"}})
+
+    ParameterSet({"param": {"sub_param": {"sub_sub_param": "value"}}})
+
     with pytest.raises(ValueError, match="invalid type"):
-        ParameterSet({"param": {"sub_param": "value"}})
+        ParameterSet({"param": {"sub_param": set()}})
 
 
 def test_validate_values_list_ok():

--- a/tests/test_run_squash.py
+++ b/tests/test_run_squash.py
@@ -1,5 +1,6 @@
 import polars as pl
 import polars.testing
+
 from griddler import run_squash
 
 
@@ -63,4 +64,14 @@ def test_run_squash_some_parameters():
 
     expected = pl.DataFrame({"x_plus_y": [2, 12], "x": [1, 10]})
 
+    polars.testing.assert_frame_equal(output, expected, check_dtypes=False)
+
+
+def test_run_squash_nested_dict():
+    def func(ps) -> pl.DataFrame:
+        return pl.DataFrame({"x_plus_y": ps["numbers"]["x"] + ps["numbers"]["y"]})
+
+    parameter_sets = [{"numbers": {"x": 1, "y": 2}}]
+    output = run_squash(func, parameter_sets, add_hash=False)
+    expected = pl.DataFrame({"x_plus_y": 3, "numbers": pl.struct(x=1, y=2, eager=True)})
     polars.testing.assert_frame_equal(output, expected, check_dtypes=False)


### PR DESCRIPTION
It is perfectly reasonable to have something like:

```yaml
baseline_parameters:
  random_numbers:
    distribution: gamma
    shape: 1.0
    scale: 0.5
```

This PR allows conformable dict-of-dicts to be turned into polars structs and `run_squash()`ed like other kinds of parameters.