### PR TITLE
Add and test JSON support

### DIFF
--- a/griddler/griddle.py
+++ b/griddler/griddle.py
@@ -1,4 +1,5 @@
 import itertools
+import json
 
 import yaml
 
@@ -93,6 +94,21 @@ def _match_ps_nest1(parameter_set, nest):
     return all(nest[key] == parameter_set[key] for key in common_keys)
 
 
+def _read_yaml(path: str) -> dict:
+    """Read a yaml file and return the contents as a dictionary
+
+    Args:
+        path: path to yaml file
+
+    Returns:
+        dictionary
+    """
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+
+    return raw
+
+
 def read(path: str) -> list[dict]:
     """Read a griddle file, and convert to parameter sets.
 
@@ -102,7 +118,16 @@ def read(path: str) -> list[dict]:
     Returns:
         list of parameter sets
     """
-    with open(path) as f:
-        raw = yaml.safe_load(f)
+    return parse(_read_yaml(path))
 
-    return parse(raw)
+
+def read_to_json(path: str) -> str:
+    """Read a griddle file, and convert to parameter sets.
+
+    Args:
+        path: path to griddle
+
+    Returns:
+        JSON version of the list of parameter sets
+    """
+    return json.dumps(read(path), indent=2)

--- a/tests/fixtures/test_griddle_test_multiple_grid_nested.json
+++ b/tests/fixtures/test_griddle_test_multiple_grid_nested.json
@@ -1,0 +1,32 @@
+[
+  {
+    "scenario": "baseline",
+    "gamma": 0.1,
+    "R0": 1.0
+  },
+  {
+    "scenario": "baseline",
+    "gamma": 0.2,
+    "R0": 1.0
+  },
+  {
+    "scenario": "optimistic",
+    "gamma": 0.1,
+    "R0": 0.5
+  },
+  {
+    "scenario": "optimistic",
+    "gamma": 0.2,
+    "R0": 0.5
+  },
+  {
+    "scenario": "pessimistic",
+    "gamma": 0.1,
+    "R0": 2.0
+  },
+  {
+    "scenario": "pessimistic",
+    "gamma": 0.2,
+    "R0": 2.0
+  }
+]

--- a/tests/fixtures/test_griddle_test_multiple_grid_nested.yaml
+++ b/tests/fixtures/test_griddle_test_multiple_grid_nested.yaml
@@ -1,0 +1,10 @@
+baseline_parameters:
+  R0: 1.0
+grid_parameters:
+  scenario: [baseline, optimistic, pessimistic]
+  gamma: [0.1, 0.2]
+nested_parameters:
+  - scenario: optimistic
+    R0: 0.5
+  - scenario: pessimistic
+    R0: 2.0

--- a/tests/test_griddle.py
+++ b/tests/test_griddle.py
@@ -1,6 +1,6 @@
 import yaml
 
-from griddler.griddle import _match_ps_nest, parse
+from griddler.griddle import _match_ps_nest, parse, read, read_to_json
 
 
 def test_baseline_only():
@@ -63,22 +63,8 @@ def test_baseline_grid_nested():
 
 
 def test_multiple_grid_nested():
-    griddle = yaml.safe_load("""
-    baseline_parameters:
-      R0: 1.0
+    parameter_sets = read("tests/fixtures/test_griddle_test_multiple_grid_nested.yaml")
 
-    grid_parameters:
-      scenario: [baseline, optimistic, pessimistic]
-      gamma: [0.1, 0.2]
-
-    nested_parameters:
-      - scenario: optimistic
-        R0: 0.5
-      - scenario: pessimistic
-        R0: 2.0
-    """)
-
-    parameter_sets = parse(griddle)
     assert parameter_sets == [
         {"scenario": "baseline", "R0": 1.0, "gamma": 0.1},
         {"scenario": "baseline", "R0": 1.0, "gamma": 0.2},
@@ -100,3 +86,12 @@ def test_nested_dicts():
 
     parameter_sets = parse(griddle)
     assert parameter_sets == [griddle["baseline_parameters"]]
+
+
+def test_read_to_json():
+    yaml_path = "tests/fixtures/test_griddle_test_multiple_grid_nested.yaml"
+
+    with open("tests/fixtures/test_griddle_test_multiple_grid_nested.json") as f:
+        json_text = f.read()
+
+    assert read_to_json(yaml_path) + "\n" == json_text


### PR DESCRIPTION
- Create `read_to_json()`, which goes from yaml griddle to json list of params
- Refactor tests with on-disk files