### PR TITLE
Alternative grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
 # Griddler: making grids of parameters
 
-Griddler is a tool for converting human-written simulation experiment parameterizations, called "griddles," into sets of machine-readable parameter sets.
+Griddler is a tool for converting *griddles*, which are human-written files for specifying simulation experiments, into lists of machine-readable parameter specifications.
+
+An *experiment* is a set (or list, with the understanding that the order is not guaranteed) of *parameter specifications*. A parameter specification is a set of parameter name-value pairs (e.g., implemented as a JSON object or a Python dictionary.)
 
 ## Griddles
 
-Griddles have a specific syntax. In this trivial example:
+A griddle, typically written in YAML, consists of some metadata and an *experiment specification*. The experiment specification can be the experiment itself, that is, the list of parameter specs. Thus, the trivial example is:
 
 ```yaml
 version: v0.3
-parameters:
-  R0: {fix: 1.0}
+experiment: []
 ```
 
-We get a single output parameter set:
+This returns an empty list `[]` of parameter specifications. The minimal example, of a single, fixed parameter is:
+
+```yaml
+version: v0.3
+experiment: [{R0: 1.0}]
+```
+
+We get a single output parameter set, serialized as JSON:
 
 ```json
 [
@@ -20,16 +28,17 @@ We get a single output parameter set:
 ]
 ```
 
-Griddler supports **varying multiple parameters** over a grid:
+The power of griddler is in taking *products* and *unions* over experiments. The product of two experiments is the Cartesian product of their constitutent parameter specs. For example:
 
 ```yaml
 version: v0.3
-parameters:
-  R0: {vary: [1.5, 2.0]}
-  gamma: {vary: [0.3, 0.4]}
+experiment:
+  product:
+    - [{R0: 1.5}, {R0: 2.0}]
+    - [{gamma: 0.3}, {gamma: 0.4}]
 ```
 
-produces 4 output parameter sets, with all combinations of input varying parameters:
+which produces 4 output parameter sets, with all combinations of input varying parameters:
 
 ```json
 [
@@ -40,68 +49,53 @@ produces 4 output parameter sets, with all combinations of input varying paramet
 ]
 ```
 
-Griddler supports **bundles of parameters that vary together** (e.g., to produce scenarios):
+Unions become useful when combining experiments that vary different parameters. For example, an experiment might consist of some simulations where a simulated quantity follows the normal distribution and other simulations where it follows the gamma distribution. For the normal distribution simulations, we might want to grid over values of the mean and standard deviation, while in the gamma distribution simulations, we want to grid over shape and scale parameters:
 
 ```yaml
 version: v0.3
-parameters:
-  scenario:
-    R0: [low, high]
-    gamma: [low, high]
+experiment:
+  product:
+    - [{R0: 1.5}]
+    - union:
+        - product:
+          - [{distribution: normal}]
+          - [{mean: 0.5}, {mean: 1.0}, {mean: 1.5}]
+          - [{sd: 0.5}, {sd: 1.0}]
+        - product:
+          - [{distribution: gamma}]
+          - [{shape: 0.5}, {shape: 1.0}]
+          - [{scale: 0.5}, {scale: 1.0}]
 ```
 
-produces only 2 outputs:
+which produces multiple parameter sets:
 
 ```json
 [
-    {"R0": "low", "gamma": "low"},
-    {"R0": "high", "gamma": "high"}
+  {"R0": 1.5, "distribution": "normal", "mean": 0.5, "sd": 0.5},
+  {"R0": 1.5, "distribution": "normal", "mean": 0.5, "sd": 1.0},
+  {"R0": 1.5, "distribution": "normal", "mean": 1.0, "sd": 0.5},
+  // etc. with further mean/sd combinations
+  {"R0": 1.5, "distribution": "gamma", "shape": 0.5, "scale": 0.5},
+  // etc. with further shape/scale combinations
 ]
 ```
 
-Griddle **conditional parameters**, allowing for subgridding:
+### Syntax summary
+
+The griddle has syntax:
 
 ```yaml
 version: v0.3
-parameters:
-  method: {vary: [newton, brent]}
-  start_point:
-    if: {equals: {method: newton}}
-    vary: [0.25, 0.50, 0.75]
-  bounds:
-    if: {equals: {method: brent}}
-    fix: [0.0, 1.0]
+experiment:
+  <experiment-spec>
 ```
 
-which produces 4 parameter sets:
+where the experiment specification has syntax:
 
-```json
-[
-    {"method": "newton", "start_point": 0.25},
-    {"method": "newton", "start_point": 0.50},
-    {"method": "newton", "start_point": 0.75},
-    {"method": "brent", "bounds": [0.0, 1.0]}
-]
-```
-
-### Griddle template
-
-```yaml
-version: v0.3
-parameters:
-  # fixed parameter
-  NAME1: {fix: VALUE}
-  # single varying parameter
-  NAME2: {vary: [VALUE, VALUE]}
-  # varying bundle
-  BUNDLE:
-    NAME3: [VALUE, VALUE]
-    NAME4: [VALUE, VALUE]
-  # conditions and comments
-  NAME5:
-    fix: VALUE
-    if: {equals: {NAME: VALUE}}
-    comment: COMMENT
+```text
+<experiment-spec> ::= [<parameter-spec>, ...]
+                       | {"union": [<experiment-spec>, ...]}
+                       | {"product": [<experiment-spec>, ...]}
 ```
 
 ## Getting started
@@ -154,7 +148,7 @@ This source code in this repository is free: you can redistribute it and/or modi
 
 This source code in this repository is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Apache Software License for more details.
 
-You should have received a copy of the Apache Software License along with this program. If not, see http://www.apache.org/licenses/LICENSE-2.0.html
+You should have received a copy of the Apache Software License along with this program. If not, see <http://www.apache.org/licenses/LICENSE-2.0.html>
 
 The source code forked from other open source projects will inherit its license.
 

--- a/griddler/__init__.py
+++ b/griddler/__init__.py
@@ -1,152 +1,82 @@
+import functools
 import importlib.resources
 import json
-import uuid
-from typing import Any, Iterable, List, Set
+from typing import Any, Iterable, List
 
 import jsonschema
-import networkx as nx
 
 
-class Param:
-    """Base class for parameters in a griddle."""
+class Spec(dict):
+    """
+    A parameter specification, or Spec, is an extension of a dictionary,
+    with the added requirement that all keys be strings.
+    """
 
-    """Parameter name"""
-    name: str
-    """Parameter condition"""
-    if_: bool | dict
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-    @classmethod
-    def from_json(cls, name: str, spec: dict[str, Any]) -> "Param":
-        """Read a Param object from the JSON specification.
+        for key in self:
+            assert isinstance(key, str)
 
-        The `spec` is value associated with a parameter name keyword in a griddle."""
-        if "fix" in spec:
-            return FixParam(name=name, value=spec["fix"], if_=spec.get("if", True))
-        elif "vary" in spec and isinstance(spec["vary"], dict):
-            return Bundle(
-                name=name,
-                parameter_names=list(spec["vary"].keys()),
-                values=list(spec["vary"].values()),
-                if_=spec.get("if", True),
-            )
-        elif "vary" in spec and isinstance(spec["vary"], list):
-            bundle_name = f"bundle-{name}-{uuid.uuid4()}"
-            return Bundle(
-                # generate an ad hoc bundle name
-                name=bundle_name,
-                # put the parameter name inside the bundle
-                parameter_names=[name],
-                values=[spec["vary"]],
-                if_=spec.get("if", True),
-            )
+    def deparse(self) -> dict:
+        return dict(self)
+
+
+class Experiment:
+    """
+    An Experiment is set of Specs, supporting union (concatenation)
+    and Cartesian products.
+    """
+
+    def __init__(self, specs: Iterable[Spec]):
+        self.specs = list(specs)
+
+        for spec in self.specs:
+            assert isinstance(spec, Spec)
+
+    def __or__(self, other: "Experiment") -> "Experiment":
+        assert isinstance(other, Experiment)
+        return Experiment(self.specs + other.specs)
+
+    def __mul__(self, other: "Experiment") -> "Experiment":
+        assert isinstance(other, Experiment)
+
+        # every pair of specs should have disjoint keys
+        for x in self.specs:
+            for y in other.specs:
+                shared_keys = set(x.keys()).intersection(y.keys())
+                if len(shared_keys) > 0:
+                    raise RuntimeError(
+                        f"Keys are not disjoint in Experiment product: {shared_keys}"
+                    )
+
+        return Experiment([Spec(x | y) for x in self.specs for y in other.specs])
+
+    @staticmethod
+    def parse(x: list[dict[str, Any]] | dict[str, Any]) -> "Experiment":
+        if isinstance(x, list):
+            return Experiment([Spec(elt) for elt in x])
+        elif isinstance(x, dict):
+            assert len(x) == 1
+            key, value = list(x.items())[0]
+            assert isinstance(value, list)
+            subexperiments = [Experiment.parse(elt) for elt in value]
+            if key == "union":
+                return functools.reduce(lambda x, y: x | y, subexperiments)
+            elif key == "product":
+                return functools.reduce(lambda x, y: x * y, subexperiments)
+            else:
+                raise RuntimeError(f"Unknown experiment key: {key}")
         else:
-            raise RuntimeError(f"Unknown parameter specification: {name}: {spec}")
+            raise RuntimeError(f"Unknown experiment type: {x} of type {type(x)}")
 
-    def depends_on(self) -> Set[str]:
-        """Get the names of parameters that this parameter depends on.
+    def deparse(self) -> List[dict[str, Any]]:
+        """Convert this Experiment into a list of dictionaries.
 
         Returns:
-            List[str]: names of parameters
+            Iterable[dict[str, Any]]: list of dictionaries
         """
-        if isinstance(self.if_, bool):
-            # if this is a boolean condition, return an empty list
-            return set()
-        elif isinstance(self.if_, dict):
-            # we only support equals statements for now
-            assert len(self.if_) == 1
-            assert list(self.if_.keys()) == ["equals"]
-            assert isinstance(self.if_["equals"], dict)
-            assert len(self.if_["equals"]) == 1
-            return set(self.if_["equals"].keys())
-        else:
-            raise RuntimeError(f"Unknown condition: {self.if_}")
-
-    def eval_condition(self, parameter_set: dict[str, Any]) -> bool:
-        """Check if an `if` condition is satisfied.
-
-        Args:
-            parameter_set (dict): parameter set
-
-        Returns:
-            bool: if the spec matches the set
-        """
-        if isinstance(self.if_, bool):
-            # if this is a boolean condition, return it
-            return self.if_
-        elif isinstance(self.if_, dict):
-            # we only support equals statements for now
-            assert list(self.if_.keys()) == ["equals"]
-            assert isinstance(self.if_["equals"], dict)
-            assert len(self.if_["equals"]) == 1
-            cond_name, cond_value = list(self.if_["equals"].items())[0]
-
-            return cond_name in parameter_set and parameter_set[cond_name] == cond_value
-        else:
-            raise RuntimeError(f"Unknown condition: {self.if_}")
-
-    def augment_parameter_set(
-        self, parameter_set: dict[str, Any]
-    ) -> Iterable[dict[str, Any]]:
-        """Add this parameter to a parameter set, potentially producing multiple
-        output parameter sets
-
-        Args:
-            parameter_set (dict): input parameter set
-
-        Returns:
-            Iterable[dict[str, Any]]: one or more output updated parameter sets
-        """
-        raise NotImplementedError
-
-
-class FixParam(Param):
-    """A fixed parameter in a griddle."""
-
-    def __init__(self, name: str, value: Any, if_: bool | dict):
-        self.name = name
-        self.value = value
-        self.if_ = if_
-
-    def augment_parameter_set(
-        self, parameter_set: dict[str, Any]
-    ) -> Iterable[dict[str, Any]]:
-        # just add this fixed value
-        assert self.name not in parameter_set
-        parameter_set[self.name] = self.value
-        return [parameter_set]
-
-
-class Bundle(Param):
-    """A varying bundle of parameters in a griddle."""
-
-    def __init__(
-        self,
-        name: str,
-        parameter_names: List[str],
-        values: List[List],
-        if_: bool | dict,
-    ):
-        self.name = name
-        self.parameter_names = parameter_names
-        self.values = values
-        self.if_ = if_
-
-        # check that all values have the same length
-        n = [len(v) for v in values]
-        assert len(set(n)) == 1, (
-            f"Varying parameters in bundle {name} must have the same number of values"
-        )
-        self.n = n[0]
-
-    def augment_parameter_set(
-        self, parameter_set: dict[str, Any]
-    ) -> Iterable[dict[str, Any]]:
-        out = [parameter_set.copy() for _ in range(self.n)]
-        for i in range(self.n):
-            for name, value in zip(self.parameter_names, self.values):
-                out[i][name] = value[i]
-
-        return out
+        return [spec.deparse() for spec in self.specs]
 
 
 class Griddle:
@@ -163,121 +93,15 @@ class Griddle:
         # check for version
         assert self.griddle["version"] == "v0.3", "Only v0.3 griddles are supported"
 
-    def parse(self) -> List[dict]:
+    def parse(self) -> List[dict[str, Any]]:
         """Convert this griddle into a list of parameter sets.
 
         Returns:
             List[dict]: list of parameter sets
         """
         # extract the parameters section of the griddle
-        params = self.griddle["parameters"]
-        assert isinstance(params, dict)
-
-        return self._parse_params(params)
-
-    @classmethod
-    def _parse_params(cls, params_dict: dict[str, Any]) -> List[dict]:
-        """Parse the parameters section of the griddle"""
-        # parse the parameters into objects
-        params = [Param.from_json(name, spec) for name, spec in params_dict.items()]
-
-        # check that no parameter names are repeated
-        cls._validate_parameter_names(params)
-
-        # determine the order in which we'll add parameters to the parameter sets
-        param_order = cls._get_param_order(params)
-
-        # initialize the output parameter sets
-        parameter_sets = [{}]
-
-        # go through the params in order
-        for param in sorted(params, key=lambda x: param_order.index(x.name)):
-            # each time, iterate over all the parameter sets, augmenting them
-            # to create a new list of parameter sets
-            new_parameter_sets = []
-
-            for ps in parameter_sets:
-                # check if the `if` condition is satisfied
-                if param.eval_condition(ps):
-                    # get the updated (& potentially multiplied) parameter sets
-                    augmented_sets = param.augment_parameter_set(ps)
-                    # add the new parameter sets to the list
-                    new_parameter_sets.extend(augmented_sets)
-                else:
-                    # if the condition isn't satisfied, just add the old
-                    # parameter set to the list
-                    new_parameter_sets.append(ps)
-
-            parameter_sets = new_parameter_sets
-
-        return parameter_sets
-
-    @classmethod
-    def _get_param_order(cls, params: Iterable[Param]) -> List[str]:
-        """Get the order of parameters in the griddle, using the DAG of `if`s.
-
-        Args:
-            params (List[Param]): list of parameter objects
-
-        Returns:
-            List[str]: order of parameters (by name)
-        """
-        # make a mapping from parameter name to parameter/bundle name/ID
-        name_map = {}
-
-        for param in params:
-            if isinstance(param, FixParam):
-                # for fixed params, there is no ambiguity
-                name_map[param.name] = param.name
-            elif isinstance(param, Bundle):
-                # for bundles, point from the parameter names in the bundle to
-                # the bundle ID
-                for name in param.parameter_names:
-                    name_map[name] = param.name
-            else:
-                raise RuntimeError(f"Unknown parameter type: {type(param)}")
-
-        # create a directed graph from the `if`s
-        # nodes are the parameters/bundles
-        G = nx.DiGraph()
-        for param in params:
-            G.add_node(param.name)
-
-            # if this parameter depends on other ones, add edges from
-            # those parameters to this one
-            for cond_param_name in param.depends_on():
-                # get the parameter name from the name map
-                cond_obj_name = name_map[cond_param_name]
-                G.add_edge(cond_obj_name, param.name)
-
-        # confirm this graph is a DAG
-        if not nx.is_directed_acyclic_graph(G):
-            raise RuntimeError("The `if` conditions form a cycle.")
-
-        # get the topological sort of the graph
-        return list(nx.topological_sort(G))
-
-    @classmethod
-    def _validate_parameter_names(cls, params: Iterable[Param]) -> None:
-        """Check that there are no name collisions, especially with the varying
-        bundles.
-
-        Args:
-            params (List[Param]): list of parameter objects
-        """
-        names = []
-        for param in params:
-            if isinstance(param, FixParam):
-                assert param.name not in names, (
-                    f"Duplicate parameter name: {param.name}"
-                )
-                names.append(param.name)
-            elif isinstance(param, Bundle):
-                for name in param.parameter_names:
-                    assert name not in names, f"Duplicate parameter name: {name}"
-                    names.append(name)
-            else:
-                raise RuntimeError(f"Unknown parameter type: {type(param)}")
+        experiment = self.griddle["experiment"]
+        return Experiment.parse(experiment).deparse()
 
     @staticmethod
     def load_schema() -> dict:

--- a/griddler/schema.json
+++ b/griddler/schema.json
@@ -7,80 +7,52 @@
         "version": {
             "type": "string"
         },
-        "parameters": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "object",
-                "oneOf": [
-                    {
-                        "description": "fixed parameter",
-                        "properties": {
-                            "fix": {},
-                            "if": {
-                                "$ref": "#/$defs/if_condition"
-                            },
-                            "comment": {}
-                        },
-                        "required": [
-                            "fix"
-                        ],
-                        "additionalProperties": false
-                    },
-                    {
-                        "description": "varying bundle of parameters",
-                        "properties": {
-                            "vary": {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "array"
-                                }
-                            },
-                            "if": {
-                                "$ref": "#/$defs/if_condition"
-                            },
-                            "comment": {}
-                        },
-                        "required": [
-                            "vary"
-                        ],
-                        "additionalProperties": false
-                    },
-                    {
-                        "description": "varying bundle, with one parameter, in short form",
-                        "properties": {
-                            "vary": {
-                                "type": "array"
-                            },
-                            "if": {
-                                "$ref": "#/$defs/if_condition"
-                            },
-                            "comment": {}
-                        },
-                        "required": [
-                            "vary"
-                        ],
-                        "additionalProperties": false
-                    }
-                ]
-            }
+        "experiment": {
+            "$ref": "#/$defs/experiment"
         }
     },
     "required": [
         "version",
-        "parameters"
+        "experiment"
     ],
     "additionalProperties": false,
     "$defs": {
-        "if_condition": {
-            "type": "object",
-            "properties": {
-                "equals": {
+        "experiment": {
+            "oneOf": [
+                {
+                    "$comment": "list of specs",
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                {
+                    "$comment": "union of experiments",
                     "type": "object",
-                    "minProperties": 1,
-                    "maxProperties": 1
+                    "properties": {
+                        "union": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/experiment"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "$comment": "product of experiments",
+                    "type": "object",
+                    "properties": {
+                        "product": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/experiment"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
                 }
-            },
-            "additionalProperties": false
+            ]
         }
     }
 }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+import jsonschema
+
+import griddler
+
+schema = griddler.Griddle.load_schema()
+
+
+def validate_griddle(x: dict) -> None:
+    """Validate an entire griddle"""
+    jsonschema.Draft202012Validator(schema).validate(x)
+
+
+def validate_experiment(x: dict | list) -> None:
+    """Validate the experiment inside a griddle"""
+    validate_griddle({"version": "my_version", "experiment": x})

--- a/tests/test_griddle.py
+++ b/tests/test_griddle.py
@@ -1,6 +1,6 @@
-import pytest
+from typing import List
 
-from griddler import FixParam, Griddle, Param
+from griddler import Experiment, Griddle
 
 
 def assert_list_setequal(a, b):
@@ -13,217 +13,78 @@ def assert_list_setequal(a, b):
         assert x in a, f"{x} not in {a}"
 
 
-def params_from_json(params_dict):
-    """Convert a dictionary of parameters into a list of Param objects."""
-    return [Param.from_json(name, spec) for name, spec in params_dict.items()]
-
-
-class TestParamOrder:
-    def test_fail_not_dag_minimal(self):
-        params = {
-            "A": {"fix": "a", "if": {"equals": {"B": "b"}}},
-            "B": {"fix": "b", "if": {"equals": {"A": "a"}}},
-        }
-        with pytest.raises(RuntimeError, match="The `if` conditions form a cycle"):
-            Griddle._get_param_order(params_from_json(params))
-
-    def test_simple(self):
-        # B depends on A, so A should come first
-        params = {
-            "A": {"fix": "a"},
-            "B": {"fix": "b", "if": {"equals": {"A": "a"}}},
-        }
-        assert Griddle._get_param_order(params_from_json(params)) == ["A", "B"]
-
-    def test_multiple(self):
-        # B depends on A, so A should come first
-        # C isn't part of the DAG, so it can come in any place
-        params = {
-            "A": {"fix": "a"},
-            "B": {"fix": "b", "if": {"equals": {"A": "a"}}},
-            "C": {"fix": "c"},
-        }
-        order = Griddle._get_param_order(params_from_json(params))
-
-        assert set(order) == {"A", "B", "C"}
-        assert order.index("A") < order.index("B")
-
-
-class TestValidateNames:
-    def test_simple(self):
-        params_dict = {"A": {"fix": "a"}, "B": {"vary": {"A": [1, 2]}}}
-        params = params_from_json(params_dict)
-        with pytest.raises(AssertionError, match=r"(?i)duplicate parameter name"):
-            Griddle._validate_parameter_names(params)
-
-
-class TestEvalCondition:
-    def test_trivial(self):
-        assert FixParam(name="x", value="x", if_=True).eval_condition({}) is True
-
-    def test_trivial_with_value(self):
-        assert (
-            FixParam(name="x", value="x", if_=True).eval_condition({"y": "y"}) is True
-        )
-
-    def test_simple_equals(self):
-        assert (
-            FixParam(name="x", value="x", if_={"equals": {"y": "y"}}).eval_condition(
-                {"y": "y"}
-            )
-            is True
-        )
-
-        assert (
-            FixParam(name="x", value="x", if_={"equals": {"y": "y"}}).eval_condition(
-                {"y": "z"}
-            )
-            is False
-        )
-
-
-class TestConditionDependsOn:
-    def test_fixed_none(self):
-        assert FixParam(name="x", value="x", if_=True).depends_on() == set()
-
-    def test_fixed(self):
-        assert FixParam(
-            name="x", value="x", if_={"equals": {"y": "y"}}
-        ).depends_on() == {"y"}
+def parse_experiment(x: dict | list) -> List[dict]:
+    return Experiment.parse(x).deparse()
 
 
 class TestParse:
     def test_minimal(self):
-        griddle = {"version": "v0.3", "parameters": {}}
-        parameter_sets = Griddle(griddle).parse()
-        assert parameter_sets == [{}]
+        griddle = {"version": "v0.3", "experiment": []}
+        assert Griddle(griddle).parse() == []
+
+    def test_almost_minimal(self):
+        griddle = {"version": "v0.3", "experiment": [{}]}
+        assert Griddle(griddle).parse() == [{}]
 
     def test_fixed_only(self):
-        griddle = {"version": "v0.3", "parameters": {"R0": {"fix": 1.5}}}
-        parameter_sets = Griddle(griddle).parse()
-        assert parameter_sets == [{"R0": 1.5}]
+        griddle = {"version": "v0.3", "experiment": [{"R0": 1.5}]}
+        assert Griddle(griddle).parse() == [{"R0": 1.5}]
 
-    def test_vary_one_canonical_one_value(self):
-        params = {"my_bundle": {"vary": {"R0": [1.0]}}}
-        parameter_sets = Griddle._parse_params(params)
-        assert parameter_sets == [{"R0": 1.0}]
+    def test_simple_experiment(self):
+        expt = [{"R0": 1.5}, {"R0": 2.5}]
+        assert parse_experiment(expt) == expt
 
-    def test_vary_one_canonical(self):
-        params = {"my_bundle": {"vary": {"R0": [1.0, 2.0]}}}
-        parameter_sets = Griddle._parse_params(params)
-        assert_list_setequal(parameter_sets, [{"R0": 1.0}, {"R0": 2.0}])
+    def test_experiment_union(self):
+        expt = {"union": [[{"R0": 1.5}], [{"gamma": 1.0}]]}
+        assert parse_experiment(expt) == [{"R0": 1.5}, {"gamma": 1.0}]
 
-    def test_vary_one_short(self):
-        params = {"R0": {"vary": [1.0, 2.0]}}
-        parameter_sets = Griddle._parse_params(params)
-        assert_list_setequal(
-            parameter_sets,
-            [
-                {"R0": 1.0},
-                {"R0": 2.0},
-            ],
-        )
-
-    def test_2x2_grid(self):
-        params = {"R0": {"vary": [1.0, 2.0]}, "gamma": {"vary": [1.0, 2.0]}}
-        parameter_sets = Griddle._parse_params(params)
-        assert_list_setequal(
-            parameter_sets,
-            [
-                {"R0": 1.0, "gamma": 1.0},
-                {"R0": 1.0, "gamma": 2.0},
-                {"R0": 2.0, "gamma": 1.0},
-                {"R0": 2.0, "gamma": 2.0},
-            ],
-        )
-
-    def test_bundle(self):
-        params = {
-            "R0": {"fix": 1.0},
-            "scenario_bundle": {
-                "vary": {"scenario": ["bad", "good"], "gamma": [1.0, 2.0]}
-            },
+    def test_experiment_product(self):
+        expt = {
+            "product": [[{"R0": 1.5}, {"R0": 2.5}], [{"gamma": 1.0}, {"gamma": 2.0}]]
         }
-        parameter_sets = Griddle._parse_params(params)
-        assert_list_setequal(
-            parameter_sets,
-            [
-                {"R0": 1.0, "scenario": "bad", "gamma": 1.0},
-                {"R0": 1.0, "scenario": "good", "gamma": 2.0},
-            ],
-        )
-
-    def test_vary_one_vary_bundle(self):
-        params = {
-            "gamma": {"vary": [0.1, 0.2]},
-            "scenario": {"vary": {"R0": [1.0, 2.0], "theta": [1.0, 2.0]}},
-        }
-        parameter_sets = Griddle._parse_params(params)
-
-        expected = [
-            {"gamma": 0.1, "R0": 1.0, "theta": 1.0},
-            {"gamma": 0.1, "R0": 2.0, "theta": 2.0},
-            {"gamma": 0.2, "R0": 1.0, "theta": 1.0},
-            {"gamma": 0.2, "R0": 2.0, "theta": 2.0},
+        assert parse_experiment(expt) == [
+            {"R0": 1.5, "gamma": 1.0},
+            {"R0": 1.5, "gamma": 2.0},
+            {"R0": 2.5, "gamma": 1.0},
+            {"R0": 2.5, "gamma": 2.0},
         ]
 
-        assert_list_setequal(parameter_sets, expected)
-
-    def test_if_trivial(self):
-        params = {"x": {"fix": "X", "if": True}}
-        parameter_sets = Griddle._parse_params(params)
-        assert parameter_sets == [{"x": "X"}]
-
-    def test_if_simple(self):
-        params = {"x": {"fix": "X"}, "y": {"fix": "Y", "if": {"equals": {"x": "X"}}}}
-        parameter_sets = Griddle._parse_params(params)
-        assert parameter_sets == [{"x": "X", "y": "Y"}]
-
-    def test_subgrid(self):
-        params = {
-            "state_and_capital": {
-                "vary": {
-                    "state": ["Virginia", "North Dakota"],
-                    "capital": ["Richmond", "Pierre"],
-                }
-            },
-            "beach_town": {
-                "if": {"equals": {"state": "Virginia"}},
-                "vary": ["Virginia Beach", "Chincoteague", "Colonial Beach"],
-            },
+    def test_nested1(self):
+        expt = {
+            "product": [
+                [{"R0": 1.5}],
+                {"union": [[{"method": "brent"}], [{"lower": 0.0}]]},
+            ]
         }
-        parameter_sets = Griddle._parse_params(params)
-        print(parameter_sets)
-        expected = [
-            {
-                "state": "Virginia",
-                "capital": "Richmond",
-                "beach_town": "Virginia Beach",
-            },
-            {"state": "Virginia", "capital": "Richmond", "beach_town": "Chincoteague"},
-            {
-                "state": "Virginia",
-                "capital": "Richmond",
-                "beach_town": "Colonial Beach",
-            },
-            {"state": "North Dakota", "capital": "Pierre"},
+        assert parse_experiment(expt) == [
+            {"R0": 1.5, "method": "brent"},
+            {"R0": 1.5, "lower": 0.0},
         ]
-        assert_list_setequal(parameter_sets, expected)
 
-    def test_conditional_newton_example(self):
-        params_dict = {
-            "method": {"vary": ["newton", "brent"]},
-            "start_point": {
-                "if": {"equals": {"method": "newton"}},
-                "vary": [0.25, 0.50, 0.75],
-            },
-            "bounds": {"if": {"equals": {"method": "brent"}}, "fix": [0.0, 1.0]},
+    def test_nested2(self):
+        expt = {
+            "product": [
+                [{"R0": 1.5}],
+                {
+                    "union": [
+                        [{"method": "brent", "lower_bound": 0.0, "upper_bound": 1.0}],
+                        {
+                            "product": [
+                                [{"method": "newton"}],
+                                [
+                                    {"start_point": 0.25},
+                                    {"start_point": 0.50},
+                                    {"start_point": 0.75},
+                                ],
+                            ]
+                        },
+                    ]
+                },
+            ],
         }
-        parameter_sets = Griddle._parse_params(params_dict)
-        expected = [
-            {"method": "newton", "start_point": 0.25},
-            {"method": "newton", "start_point": 0.5},
-            {"method": "newton", "start_point": 0.75},
-            {"method": "brent", "bounds": [0.0, 1.0]},
+        assert parse_experiment(expt) == [
+            {"R0": 1.5, "method": "brent", "lower_bound": 0.0, "upper_bound": 1.0},
+            {"R0": 1.5, "method": "newton", "start_point": 0.25},
+            {"R0": 1.5, "method": "newton", "start_point": 0.50},
+            {"R0": 1.5, "method": "newton", "start_point": 0.75},
         ]
-        assert_list_setequal(parameter_sets, expected)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -12,96 +12,50 @@ def validate_griddle(x: dict) -> None:
     jsonschema.Draft202012Validator(schema).validate(x)
 
 
-def validate_parameters(x: dict) -> None:
-    """Validate the parameters dictionary inside a griddle"""
-    validate_griddle({"version": "my_version", "parameters": x})
+def validate_experiment(x: dict | list) -> None:
+    """Validate the experiment inside a griddle"""
+    validate_griddle({"version": "my_version", "experiment": x})
 
 
 def test_v0_2_griddle_fails():
     with pytest.raises(jsonschema.exceptions.ValidationError):
-        validate_griddle({"baseline_parameters": {"R0": 1.5, "gamma": 2.0}})
+        validate_griddle({"experiment": [{"R0": 1.0}]})
 
 
 def test_griddle_minimal():
     """Minimal griddle"""
-    validate_griddle({"version": "my_version", "parameters": {}})
+    validate_griddle({"version": "my_version", "experiment": []})
 
 
-def test_griddle_one():
-    """Griddle with one dimension"""
-    validate_griddle({"version": "my_version", "parameters": {"R0": {"fix": 1.5}}})
+def test_griddle_one_spec():
+    """Griddle with one fixed parameter"""
+    validate_griddle({"version": "my_version", "experiment": [{"R0": 1.5}]})
 
 
-def test_fix_scalar():
-    """Fixed parameter with canonical form"""
-    validate_parameters({"R0": {"fix": 1.0}})
+def test_experiment_two_spec():
+    """Experiment with two specs"""
+    validate_experiment([{"R0": 1.5}, {"R0": 2.5}])
 
 
-def test_fix_array():
-    """Fixed parameter with array form"""
-    validate_parameters({"R0": {"fix": [1.0, 2.0]}})
+def test_experiment_union():
+    """Experiment with union of two specs"""
+    validate_experiment({"union": [[{"R0": 1.5}], [{"gamma": 1.0}]]})
 
 
-def test_fix_multiple():
-    """Multiple fixed parameters"""
-    validate_parameters(
-        {"R0": {"fix": 1.0}, "gamma": {"fix": 2.0}, "beta": {"fix": 3.0}}
+def test_experiment_product():
+    """Experiment with product of two specs"""
+    validate_experiment(
+        {"product": [[{"R0": 1.5}, {"R0": 2.5}], [{"gamma": 1.0}, {"gamma": 2.0}]]}
     )
 
 
-def test_fixed_fail_on_bad_field():
-    """Fixed parameter with bad field"""
-    with pytest.raises(jsonschema.exceptions.ValidationError):
-        validate_parameters({"R0": {"fix": 1.0, "bad_field": True}})
-
-
-def test_vary_one():
-    """Varying bundle with one parameter"""
-    validate_parameters({"R0_bundle": {"vary": {"R0": [1.0, 2.0]}}})
-
-
-def test_vary_fail_on_bad_field():
-    """Varying bundle with one parameter with bad field"""
-    with pytest.raises(jsonschema.exceptions.ValidationError):
-        validate_parameters(
-            {"R0_bundle": {"vary": {"R0": [1.0, 2.0]}, "bad_field": True}}
-        )
-
-
-def test_vary_multiple():
-    """Varying bundle with multiple parameters"""
-    validate_parameters(
-        {"my_bundle": {"vary": {"R0": [1.0, 2.0], "gamma": [2.0, 3.0]}}}
-    )
-
-
-def test_vary_one_short():
-    """Varying bundle with one parameter, in short form"""
-    validate_parameters({"R0": {"vary": [1.0, 2.0]}})
-
-
-def test_conditioned_fixed():
-    """Conditioned fixed parameter"""
-    validate_parameters({"R0": {"fix": 1.0, "if": {"equals": {"gamma": 2.0}}}})
-
-
-def test_conditioned_vary():
-    """Conditioned varying bundle in canonical_form"""
-    validate_parameters(
+def test_experiment_product_union():
+    """Experiment that is a product of a union of two experiments"""
+    validate_experiment(
         {
-            "my_bundle": {
-                "vary": {"R0": [1.0, 2.0], "gamma": [2.0, 3.0]},
-                "if": {"equals": {"R0": 1.0}},
-            }
+            "product": [
+                [{"R0": 1.5}],
+                {"union": [[{"method": "brent"}], [{"lower": 0.0}]]},
+            ]
         }
     )
-
-
-def test_conditioned_vary_short():
-    """Conditioned varying bundle, with one parameter in short form"""
-    validate_parameters({"R0": {"vary": [1.0, 2.0], "if": {"equals": {"gamma": 2.0}}}})
-
-
-def test_fixed_comment():
-    """Fixed parameter with comment"""
-    validate_parameters({"R0": {"fix": 1.0, "comment": "This is a comment"}})


### PR DESCRIPTION
See #67 for rationale behind this grammar. It has a more fiddly syntax, but has conceptual elegance and a substantially simpler implementation:

- `griddler/__init__.py` is much shorter
- There are no DAGs

Resolves #67 