### PR TITLE
Theory

### DIFF
--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -46,8 +46,8 @@ In the Python implementation, Specifications are implemented as dictionaries:
 - The neutral element $0_M$ is represented by the absence of that key from the dictionary.
 - The Specification's update $\oplus$ operation is implemented by the dictionary's [`update`](https://docs.python.org/3/library/stdtypes.html#dict.update) method, which is also written `|`.
 
-An Experiment is a set of Specifications, equipped with two operations: _union_ $\cap$, which is the union of the sets of Specifications, and _product_ $\otimes$, analogous to Cartesian product. For two experiments $X$ and $Y$, define $X \otimes Y = \{\vec{x} \oplus \vec{y} : \vec{x} \in X, \vec{y} \in Y\}$.
+An Experiment is a set of Specifications, equipped with two operations: _union_ $\cup$, which is the union of the sets of Specifications, and _product_ $\otimes$, analogous to Cartesian product. For two experiments $X$ and $Y$, define $X \otimes Y = \{\vec{x} \oplus \vec{y} : \vec{x} \in X, \vec{y} \in Y\}$.
 
-This structure is a hemiring. Union $\cap$ is a commutative monoid, whose identity element is the empty Experiment $\varnothing$. Product $\otimes$ is a semigroup: it is associative but has no identity element. (Experiments do not form a semiring because of this absence of an identity element for the product operation.)
+This structure is a hemiring. Union $\cup$ is a commutative monoid, whose identity element is the empty Experiment $\varnothing$. Product $\otimes$ is a semigroup: it is associative but has no identity element. (Experiments do not form a semiring because of this absence of an identity element for the product operation.)
 
 Note that, similar to a ring, product $\otimes$ is commutative, and product with the union identity always returns that identity: $X \otimes \varnothing = \varnothing$ for any Experiment $X$.

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -18,3 +18,36 @@ These operations, combined in different ways, are sufficient to produce all sort
 In the `griddler` package, Parameters are implemented key-value pairs in a `Spec` object, which is an extention of a dictionary with the requirement that the keys be strings. The `Experiment` class, which holds a set of `Spec` objects, supports union via the `|` operator and product via `*`.
 
 See the [API reference](api.md) for more details.
+
+## Theory
+
+Mathematically speaking, Experiments are [hemirings](https://en.wikipedia.org/wiki/Semiring#Generalizations), and Specifications and Parameter values are [monoids](https://en.wikipedia.org/wiki/Monoid). To see this, replace the informal definitions above with more rigorous ones.
+
+A Specification $\vec{x} = (x_1, \ldots, x_N)$ is a tuple of Parameter values $x_i$, where $N$ is the total number of parameter names we will be interested in. ($N$ may be greater than the number of parameters with assigned values in any particular Specification.) The space of the $x_i$ includes all possible parameter values as well as an additional neutral element $0_M$. The $x_i$ have a single binary operation _update_ $\oplus$ that returns the right element, unless that element is the neutral element:
+
+```math
+x \oplus y = \begin{cases}
+x & y = 0_M \\
+y & \text{otherwise}
+\end{cases}
+```
+
+Note that this structure is a monoid, not a [group](<https://en.wikipedia.org/wiki/Group_(mathematics)>), because the update operation lacks an inverse (i.e., for all $x \neq 0_M$, there is no $x^{-1}$ such that $x \oplus x^{-1} = 0_M$). Note also that this monoid is not commutative (i.e., $x \oplus y \neq y \oplus x$ in general).
+
+Specifications have an analogous, elementwise "update" operation, and are therefore also a monoid:
+
+```math
+\vec{x} \oplus \vec{y} = (x_1 \oplus y_1, \ldots, x_N \oplus y_N)
+```
+
+In the Python implementation, Specifications are implemented as dictionaries:
+
+- Specifications are indexed by parameter names rather than integers $i$ to index the values.
+- The neutral element $0_M$ is represented by the absence of that key from the dictionary.
+- The Specification's update $\oplus$ operation is implemented by the dictionary's [`update`](https://docs.python.org/3/library/stdtypes.html#dict.update) method, which is also written `|`.
+
+An Experiment is a set of Specifications, equipped with two operations: _union_ $\cap$, which is the union of the sets of Specifications, and _product_ $\otimes$, analogous to Cartesian product. For two experiments $X$ and $Y$, define $X \otimes Y = \{\vec{x} \oplus \vec{y} : \vec{x} \in X, \vec{y} \in Y\}$.
+
+This structure is a hemiring. Union $\cap$ is a commutative monoid, whose identity element is the empty Experiment $\varnothing$. Product $\otimes$ is a semigroup: it is associative but has no identity element. (Experiments do not form a semiring because of this absence of an identity element for the product operation.)
+
+Note that, similar to a ring, product $\otimes$ is commutative, and product with the union identity always returns that identity: $X \otimes \varnothing = \varnothing$ for any Experiment $X$.

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -19,7 +19,7 @@ See the [API reference](api.md) for more details.
 
 ## Theory
 
-Mathematically speaking, Specs are their operation are a [monoid](https://en.wikipedia.org/wiki/Monoid), while Experiments and their operations are a [hemiring](https://en.wikipedia.org/wiki/Semiring#Generalizations). Specifically, a Spec $\vec{x} = (x_1, \ldots, x_N)$ is a tuple, where $N$ is the total number of parameters we will be interested in. ($N$ may be greater than the number of parameters with assigned values in any particular Spec.) The space of the $x_i$ includes all possible parameter values as well as an additional neutral element $0_M$. The $x_i$ have a single binary operation _update_ $\uparrow$ that returns the right element, unless that element is the neutral element:
+Mathematically speaking, Specs and their one operation form a non-communtative [monoid](https://en.wikipedia.org/wiki/Monoid), while Experiments and their two operations form a [semiring](https://en.wikipedia.org/wiki/Semiring). Specifically, a Spec $\vec{x} = (x_1, \ldots, x_N)$ is a [sequence](https://en.wikipedia.org/wiki/Sequence), where $N$ is the total number of parameters we will be interested in. ($N$ may be greater than the number of parameters with assigned values in any particular Spec.) The space of the $x_i$ includes all possible parameter values as well as an additional neutral element $0_M$. The $x_i$ have a single binary operation _update_ $\uparrow$ that returns the right element, unless that element is the neutral element:
 
 ```math
 x \uparrow y = \begin{cases}
@@ -38,12 +38,12 @@ Specs have an analogous update operation that is the element application of the 
 \vec{x} \uparrow \vec{y} = (x_1 \uparrow y_1, \ldots, x_N \uparrow y_N)
 ```
 
-Thus, Specs and their $\uparrow$ operator also form a monoid.
+Thus, Specs and their $\uparrow$ operator also form a non-commutative monoid.
 
 In the Python implementation, Specs are implemented as dictionaries. Dictionaries are indexed by parameter names rather than integers $i$ to index the values, and the neutral element $0_M$ is represented by the absence of that key from the dictionary.
 
 An Experiment is a set of Specs, equipped with two operations: _union_ $\cap$, which is just the union of the sets of Specs, and _product_ $\otimes$, analogous to Cartesian product. For two experiments $X$ and $Y$, define $X \otimes Y = \{\vec{x} \uparrow \vec{y} : \vec{x} \in X, \vec{y} \in Y\}$.
 
-Experiments and their operations form a hemiring. Union $\cap$ is a commutative monoid, whose identity element is the empty Experiment $\varnothing$. Product $\otimes$ is a semigroup: it is associative but has no identity element. (Experiments do not form a semiring because of this absence of an identity element for the product operation.)
+Experiments and their operations form a semiring. Union $\cap$ is a commutative monoid, whose identity element is the empty Experiment $\varnothing$ (i.e., a set of no Specs at all). Product $\otimes$ is a monoid with identity element $\{ (0_M, \ldots, 0_M) \}$ (i.e., an Experiment consisting of a single, totally unspecified Spec).
 
-Note that, similar to a ring, product $\otimes$ is commutative, and product with the union identity always returns that identity: $X \otimes \varnothing = \varnothing$ for any Experiment $X$.
+Note that, similar to a ring, product $\otimes$ is commutative, and product with the union identity $\varnothing$ always returns that identity, that is, $X \otimes \varnothing = \varnothing \otimes X = \varnothing$ for any Experiment $X$.

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -1,29 +1,25 @@
 # Core concepts
 
-There is no common nomenclature for the problem griddler solves, so we [make up our own](https://xkcd.com/927/). There are 3 core entities in griddler:
+There is no common nomenclature for the problem griddler solves, so we [make up our own](https://xkcd.com/927/). There are 2 core concepts in griddler: the _Spec_ and the _Experiment_.
 
-- A _Parameter_ is a paired name and value, encoding an idea like "the reproduction number is 1.2." (Lower-case "parameter" and "parameterization" are used as non-specific, common sense terms.)
-- A _Specification_ is a set (i.e., unordered list) of Parameters. A Specification can be all the variables and other configuration required to specify and run a single simulation.
-- An _Experiment_ is a set of Specifications. An Experiment might include replicate simulations with different random seeds, simple grids of parameter values (hence, "griddler"), or more complex combinations of parameters.
+A Spec is a collection of parameter values. Informally, it is a set of parameter name-value pairs. Typically, a Spec corresponds to the variables and other configuration required to specify and run a single simulation. One Spec can be _updated_ by another one, creating a new Spec with values from the updating Spec.
 
-And there are 2 core operations:
+An Experiment is a set of Specs. An Experiment might include replicate simulations with different random seeds, simple grids of parameter values (hence, "griddler"), or more complex combinations of parameters. Experiments support two operations:
 
-- The _union_ of two Experiments, which is just the union of the their constituent Specifications, is another Experiment.
-- The _product_ of two Experiments, similar to a Cartesian product, is another Experiment consisting of the unions of all possible pairs of Specifications formed by taking one Specification from each of the two Experiments. This requires that all pairs of Specifications are _disjoint_, that is, that they share no Parameters with the same name.
+- The _union_ of two Experiments, which is just the union of the their constituent Specs, is another Experiment.
+- The _product_ of two Experiments, similar to a Cartesian product, is another Experiment formed by taking each Spec in one Experiment and updating it with each Spec in the other Experiment.
 
-These operations, combined in different ways, are sufficient to produce all sorts of simulations!
+Experiments, combined with unions and products, are sufficient to produce all sorts of simulations!
 
 ## Implementation
 
-In the `griddler` package, Parameters are implemented key-value pairs in a `Spec` object, which is an extention of a dictionary with the requirement that the keys be strings. The `Experiment` class, which holds a set of `Spec` objects, supports union via the `|` operator and product via `*`.
+In the `griddler` package, Specs are just dictionaries, which have the `update` (or `|`) operation. Experiments are objects of the `Experiment` class. Each `Experiment` holds a set of Specs, supports `.union()` (or `|`) and `.product()` (or `*`).
 
 See the [API reference](api.md) for more details.
 
 ## Theory
 
-Mathematically speaking, Experiments are [hemirings](https://en.wikipedia.org/wiki/Semiring#Generalizations), and Specifications and Parameter values are [monoids](https://en.wikipedia.org/wiki/Monoid). To see this, replace the informal definitions above with more rigorous ones.
-
-A Specification $\vec{x} = (x_1, \ldots, x_N)$ is a tuple of Parameter values $x_i$, where $N$ is the total number of parameter names we will be interested in. ($N$ may be greater than the number of parameters with assigned values in any particular Specification.) The space of the $x_i$ includes all possible parameter values as well as an additional neutral element $0_M$. The $x_i$ have a single binary operation _update_ $\oplus$ that returns the right element, unless that element is the neutral element:
+Mathematically speaking, Specs are their operation are a [monoid](https://en.wikipedia.org/wiki/Monoid), while Experiments and their operations are a [hemiring](https://en.wikipedia.org/wiki/Semiring#Generalizations). Specifically, a Spec $\vec{x} = (x_1, \ldots, x_N)$ is a tuple, where $N$ is the total number of parameters we will be interested in. ($N$ may be greater than the number of parameters with assigned values in any particular Spec.) The space of the $x_i$ includes all possible parameter values as well as an additional neutral element $0_M$. The $x_i$ have a single binary operation _update_ $\oplus$ that returns the right element, unless that element is the neutral element:
 
 ```math
 x \oplus y = \begin{cases}
@@ -32,22 +28,20 @@ y & \text{otherwise}
 \end{cases}
 ```
 
-Note that this structure is a monoid, not a [group](<https://en.wikipedia.org/wiki/Group_(mathematics)>), because the update operation lacks an inverse (i.e., for all $x \neq 0_M$, there is no $x^{-1}$ such that $x \oplus x^{-1} = 0_M$). Note also that this monoid is not commutative (i.e., $x \oplus y \neq y \oplus x$ in general).
+Note the values and the operation $\oplus$ form a monoid, not a [group](<https://en.wikipedia.org/wiki/Group_(mathematics)>), because the $\oplus$ operation lacks an inverse (i.e., for all $x \neq 0_M$, there is no $x^{-1}$ such that $x \oplus x^{-1} = 0_M$). Note also that this monoid is not commutative (i.e., $x \oplus y \neq y \oplus x$ in general).
 
-Specifications have an analogous, elementwise "update" operation, and are therefore also a monoid:
+Specs have an analogous update operation that is the element application of the value-wise update operation:
 
 ```math
 \vec{x} \oplus \vec{y} = (x_1 \oplus y_1, \ldots, x_N \oplus y_N)
 ```
 
-In the Python implementation, Specifications are implemented as dictionaries:
+Thus, Specs and their $\oplus$ operator also form a monoid.
 
-- Specifications are indexed by parameter names rather than integers $i$ to index the values.
-- The neutral element $0_M$ is represented by the absence of that key from the dictionary.
-- The Specification's update $\oplus$ operation is implemented by the dictionary's [`update`](https://docs.python.org/3/library/stdtypes.html#dict.update) method, which is also written `|`.
+In the Python implementation, Specs are implemented as dictionaries. Dictionaries are indexed by parameter names rather than integers $i$ to index the values, and the neutral element $0_M$ is represented by the absence of that key from the dictionary.
 
-An Experiment is a set of Specifications, equipped with two operations: _union_ $\cup$, which is the union of the sets of Specifications, and _product_ $\otimes$, analogous to Cartesian product. For two experiments $X$ and $Y$, define $X \otimes Y = \{\vec{x} \oplus \vec{y} : \vec{x} \in X, \vec{y} \in Y\}$.
+An Experiment is a set of Specs, equipped with two operations: _union_ $\cap$, which is just the union of the sets of Specs, and _product_ $\otimes$, analogous to Cartesian product. For two experiments $X$ and $Y$, define $X \otimes Y = \{\vec{x} \oplus \vec{y} : \vec{x} \in X, \vec{y} \in Y\}$.
 
-This structure is a hemiring. Union $\cup$ is a commutative monoid, whose identity element is the empty Experiment $\varnothing$. Product $\otimes$ is a semigroup: it is associative but has no identity element. (Experiments do not form a semiring because of this absence of an identity element for the product operation.)
+Experiments and their operations form a hemiring. Union $\cap$ is a commutative monoid, whose identity element is the empty Experiment $\varnothing$. Product $\otimes$ is a semigroup: it is associative but has no identity element. (Experiments do not form a semiring because of this absence of an identity element for the product operation.)
 
 Note that, similar to a ring, product $\otimes$ is commutative, and product with the union identity always returns that identity: $X \otimes \varnothing = \varnothing$ for any Experiment $X$.

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -19,28 +19,30 @@ See the [API reference](api.md) for more details.
 
 ## Theory
 
-Mathematically speaking, Specs are their operation are a [monoid](https://en.wikipedia.org/wiki/Monoid), while Experiments and their operations are a [hemiring](https://en.wikipedia.org/wiki/Semiring#Generalizations). Specifically, a Spec $\vec{x} = (x_1, \ldots, x_N)$ is a tuple, where $N$ is the total number of parameters we will be interested in. ($N$ may be greater than the number of parameters with assigned values in any particular Spec.) The space of the $x_i$ includes all possible parameter values as well as an additional neutral element $0_M$. The $x_i$ have a single binary operation _update_ $\oplus$ that returns the right element, unless that element is the neutral element:
+Mathematically speaking, Specs are their operation are a [monoid](https://en.wikipedia.org/wiki/Monoid), while Experiments and their operations are a [hemiring](https://en.wikipedia.org/wiki/Semiring#Generalizations). Specifically, a Spec $\vec{x} = (x_1, \ldots, x_N)$ is a tuple, where $N$ is the total number of parameters we will be interested in. ($N$ may be greater than the number of parameters with assigned values in any particular Spec.) The space of the $x_i$ includes all possible parameter values as well as an additional neutral element $0_M$. The $x_i$ have a single binary operation _update_ $\uparrow$ that returns the right element, unless that element is the neutral element:
 
 ```math
-x \oplus y = \begin{cases}
+x \uparrow y = \begin{cases}
 x & y = 0_M \\
 y & \text{otherwise}
 \end{cases}
 ```
 
-Note the values and the operation $\oplus$ form a monoid, not a [group](<https://en.wikipedia.org/wiki/Group_(mathematics)>), because the $\oplus$ operation lacks an inverse (i.e., for all $x \neq 0_M$, there is no $x^{-1}$ such that $x \oplus x^{-1} = 0_M$). Note also that this monoid is not commutative (i.e., $x \oplus y \neq y \oplus x$ in general).
+(This operation is [null coalescence](https://en.wikipedia.org/wiki/Null_coalescing_operator) but with the order of inputs reversed.)
+
+Note the values and the operation $\uparrow$ form a monoid, not a [group](<https://en.wikipedia.org/wiki/Group_(mathematics)>), because the $\uparrow$ operation lacks an inverse (i.e., for all $x \neq 0_M$, there is no $x^{-1}$ such that $x \uparrow x^{-1} = 0_M$). Note also that this monoid is not commutative (i.e., $x \uparrow y = y \uparrow x$ only if $x = 0_M$ or $y = 0_M$).
 
 Specs have an analogous update operation that is the element application of the value-wise update operation:
 
 ```math
-\vec{x} \oplus \vec{y} = (x_1 \oplus y_1, \ldots, x_N \oplus y_N)
+\vec{x} \uparrow \vec{y} = (x_1 \uparrow y_1, \ldots, x_N \uparrow y_N)
 ```
 
-Thus, Specs and their $\oplus$ operator also form a monoid.
+Thus, Specs and their $\uparrow$ operator also form a monoid.
 
 In the Python implementation, Specs are implemented as dictionaries. Dictionaries are indexed by parameter names rather than integers $i$ to index the values, and the neutral element $0_M$ is represented by the absence of that key from the dictionary.
 
-An Experiment is a set of Specs, equipped with two operations: _union_ $\cap$, which is just the union of the sets of Specs, and _product_ $\otimes$, analogous to Cartesian product. For two experiments $X$ and $Y$, define $X \otimes Y = \{\vec{x} \oplus \vec{y} : \vec{x} \in X, \vec{y} \in Y\}$.
+An Experiment is a set of Specs, equipped with two operations: _union_ $\cap$, which is just the union of the sets of Specs, and _product_ $\otimes$, analogous to Cartesian product. For two experiments $X$ and $Y$, define $X \otimes Y = \{\vec{x} \uparrow \vec{y} : \vec{x} \in X, \vec{y} \in Y\}$.
 
 Experiments and their operations form a hemiring. Union $\cap$ is a commutative monoid, whose identity element is the empty Experiment $\varnothing$. Product $\otimes$ is a semigroup: it is associative but has no identity element. (Experiments do not form a semiring because of this absence of an identity element for the product operation.)
 

--- a/docs/griddles.md
+++ b/docs/griddles.md
@@ -21,14 +21,14 @@ schema: v0.4
 experiment: []
 ```
 
-This returns an empty Experiment. The minimal example, of a single, fixed parameter is:
+This returns an empty Experiment (i.e., containing zero Specs). The minimal example, of a single, fixed parameter is:
 
 ```yaml
 schema: v0.4
 experiment: [{ R0: 1.0 }]
 ```
 
-This produces an Experiment with a single Specification. Serialized as JSON:
+This produces an Experiment with a single Spec. Serialized as JSON:
 
 ```json
 [{ "R0": 1.0 }]
@@ -44,7 +44,7 @@ experiment:
     - [{ gamma: 0.3 }, { gamma: 0.4 }]
 ```
 
-which produces 4 Specifications, with all combinations of input varying parameters:
+which produces 4 Specs, with all combinations of input varying parameters:
 
 ```json
 [
@@ -73,7 +73,7 @@ experiment:
             - [{ scale: 0.5 }, { scale: 1.0 }]
 ```
 
-which produces multiple Specifications:
+which produces multiple Specs:
 
 ```json
 [
@@ -98,7 +98,7 @@ experiment: <experiment>
 where the experiment has syntax:
 
 ```text
-<experiment> ::= [<parameter>, ...]
+<experiment> ::= [{<key>: <value>, ...}, ...]
                  | {"union": [<experiment>, ...]}
                  | {"product": [<experiment>, ...]}
 ```
@@ -118,7 +118,7 @@ parameters: {}
 
 #### Fixed parameters
 
-A fixed parameter has the same value in all Specifications (unless the parameter is _conditioned_).
+A fixed parameter has the same value in all Specs (unless the parameter is _conditioned_).
 
 ```yaml
 schema: v0.3
@@ -140,7 +140,7 @@ parameters:
 
 #### Varying parameter
 
-A varying parameter takes on different values in different Specifications. In the absence of conditioning or bundling, all combinations of all varying parameters will appear in the output.
+A varying parameter takes on different values in different Specs. In the absence of conditioning or bundling, all combinations of all varying parameters will appear in the output.
 
 ```yaml
 parameters:

--- a/griddler/__init__.py
+++ b/griddler/__init__.py
@@ -1,8 +1,8 @@
-__all__ = ["Spec", "Experiment", "parse"]
+__all__ = ["Experiment", "parse"]
 
 import griddler.schemas.v03
 import griddler.schemas.v04
-from griddler.core import Experiment, Spec
+from griddler.core import Experiment
 
 
 def parse(griddle: dict) -> Experiment:

--- a/griddler/__main__.py
+++ b/griddler/__main__.py
@@ -59,7 +59,7 @@ def main(args):
     else:
         raise RuntimeError(f"Invalid input format {args.from_}")
 
-    experiment_dicts = griddler.parse(raw).to_dicts()
+    experiment_dicts = griddler.parse(raw).specs
 
     if args.to == "yaml":
         yaml.dump(experiment_dicts, args.output)

--- a/griddler/schemas/v03/__init__.py
+++ b/griddler/schemas/v03/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jsonschema
 
-from griddler.core import Experiment, Spec
+from griddler.core import Experiment
 
 
 def load_schema() -> dict:
@@ -34,8 +34,8 @@ def _parse_parameters(parameters: dict[str, Any]) -> Experiment:
     dependent_keys = [key for key, value in parameters.items() if "if" in value]
     independent_keys = list(set(parameters.keys()) - set(dependent_keys))
 
-    # start with an empty experiment
-    ex = Experiment([Spec({})])
+    # start with an experiment with an empty Spec
+    ex = Experiment([dict()])
 
     # call everything a bundle at first
     for bundle_name in independent_keys + dependent_keys:
@@ -53,7 +53,7 @@ def _parse_parameters(parameters: dict[str, Any]) -> Experiment:
                     f"Fixed parameter '{bundle_name}' has impermissible keys: {bad_names}"
                 )
 
-            fix_ex = Experiment([Spec({bundle_name: bundle_value["fix"]})])
+            fix_ex = Experiment([{bundle_name: bundle_value["fix"]}])
             ex = _conditional_product(ex, fix_ex, condition)
         elif "vary" in bundle_value:
             if bad_names := set(bundle_value.keys()) - {"vary", "if", "comment"}:
@@ -61,7 +61,7 @@ def _parse_parameters(parameters: dict[str, Any]) -> Experiment:
                     f"Varying parameter '{bundle_name}' has impermissible keys: {bad_names}"
                 )
 
-            vary_ex = Experiment([Spec({bundle_name: x}) for x in bundle_value["vary"]])
+            vary_ex = Experiment([{bundle_name: x} for x in bundle_value["vary"]])
             ex = _conditional_product(ex, vary_ex, condition)
         else:
             # this is a bundle
@@ -81,7 +81,7 @@ def _parse_parameters(parameters: dict[str, Any]) -> Experiment:
             # of those parameters are matched within the Spec
             bundle_ex = Experiment(
                 [
-                    Spec({k: bundle_value[k][i] for k in bundle_value.keys()})
+                    {k: bundle_value[k][i] for k in bundle_value.keys()}
                     for i in range(bundle_len)
                 ]
             )
@@ -117,11 +117,11 @@ def _conditional_product(
         return (match_left * right) | unmatch_left
 
 
-def _if_match(spec: Spec, condition: dict[str, Any]) -> bool:
+def _if_match(spec: dict[str, Any], condition: dict[str, Any]) -> bool:
     """Check if a Spec matches a condition.
 
     Args:
-        spec (Spec): The Spec to check.
+        spec (dict[str, Any]): The Spec to check.
         condition (dict[str, Any]): The condition to match against.
 
     Returns:

--- a/griddler/schemas/v04/__init__.py
+++ b/griddler/schemas/v04/__init__.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import jsonschema
 
-from griddler.core import Experiment, Spec
+from griddler.core import Experiment
 
 
 def load_schema() -> dict:
@@ -32,7 +32,7 @@ def parse(griddle: dict) -> Experiment:
 
 def _parse_experiment(x: list[dict[str, Any]] | dict[str, Any]) -> Experiment:
     if isinstance(x, list):
-        return Experiment([Spec(elt) for elt in x])
+        return Experiment(x)
     elif isinstance(x, dict):
         assert len(x) == 1
         key, value = list(x.items())[0]

--- a/tests/griddle/test_v03.py
+++ b/tests/griddle/test_v03.py
@@ -9,7 +9,7 @@ from griddler import parse
 def text_to_dicts(text: str) -> list[dict[str, Any]]:
     """Convert a YAML text to a list of dictionaries."""
     data = yaml.safe_load(text)
-    return parse(data).to_dicts()
+    return parse(data).specs
 
 
 def test_simple():

--- a/tests/griddle/test_v04.py
+++ b/tests/griddle/test_v04.py
@@ -23,19 +23,19 @@ class TestParse:
     def parse_experiment(x: dict | list) -> List[dict]:
         """Convenience function to avoid writing the schema every time."""
         griddle = {"schema": "v0.4", "experiment": x}
-        return parse(griddle).to_dicts()
+        return parse(griddle).specs
 
     def test_minimal(self):
         griddle = {"schema": "v0.4", "experiment": []}
-        assert parse(griddle).to_dicts() == []
+        assert parse(griddle).specs == []
 
     def test_almost_minimal(self):
         griddle = {"schema": "v0.4", "experiment": [{}]}
-        assert parse(griddle).to_dicts() == [{}]
+        assert parse(griddle).specs == [{}]
 
     def test_fixed_only(self):
         griddle = {"schema": "v0.4", "experiment": [{"R0": 1.5}]}
-        assert parse(griddle).to_dicts() == [{"R0": 1.5}]
+        assert parse(griddle).specs == [{"R0": 1.5}]
 
     def test_simple_experiment(self):
         expt = [{"R0": 1.5}, {"R0": 2.5}]


### PR DESCRIPTION
- Write out formal theory of the Specs and Experiments
- Remove the "Parameter" as a mathematical object, simplifying down to one layer (cf. #77)
- Remove the "Spec" as a special programming object, simplifying down to just the `Experiment` class
- Implement Specs as dictionaries with no further checks
- Identify Specs and Experiments as [algebraic structures](https://en.wikipedia.org/wiki/Algebraic_structure) (monoid and semiring)
- Rename "Specification" as just "Spec," which makes everything easier to type and avoids confusion with the more diffuse concept of "specification"