### PR TITLE
v0.1: Retroactively support schema

### DIFF
--- a/griddler/__init__.py
+++ b/griddler/__init__.py
@@ -1,5 +1,6 @@
 __all__ = ["Spec", "Experiment", "parse"]
 
+import griddler.schemas.v01
 import griddler.schemas.v04
 from griddler.core import Experiment, Spec
 
@@ -12,5 +13,7 @@ def parse(griddle: dict) -> Experiment:
     match griddle["schema"]:
         case "v0.4":
             return griddler.schemas.v04.parse(griddle)
+        case "v0.1":
+            return griddler.schemas.v01.parse(griddle)
         case _:
             raise RuntimeError(f"Unknown griddle schema: {griddle['schema']}")

--- a/griddler/schemas/v01.py
+++ b/griddler/schemas/v01.py
@@ -1,0 +1,87 @@
+import itertools
+from collections.abc import Iterable
+
+from griddler.core import Experiment, Spec
+
+
+def _validate(griddle: dict) -> None:
+    """Validate that a griddle is well-formed"""
+    # griddle is a dict
+    assert isinstance(griddle, dict)
+    # griddle has only the known keys
+    if bad_keys := set(griddle.keys()) - {
+        "schema",
+        "baseline_parameters",
+        "grid_parameters",
+        "nested_parameters",
+    }:
+        raise RuntimeError(f"Griddle has unknown keys: {bad_keys}")
+
+    # griddle has at least one of baseline or grid
+    assert any(
+        key in griddle.keys() for key in ["baseline_parameters", "grid_parameters"]
+    )
+
+    # can only have a nest if it has a grid
+    assert (
+        "nested_parameters" not in griddle.keys() or "grid_parameters" in griddle.keys()
+    )
+
+
+def parse(griddle: dict) -> Experiment:
+    _validate(griddle)
+
+    # start with the grid, and if there is no grid, consider the grid empty
+    if "grid_parameters" in griddle:
+        param_sets = [
+            dict(zip(griddle["grid_parameters"].keys(), values))
+            for values in itertools.product(*griddle["grid_parameters"].values())
+        ]
+    else:
+        param_sets = [{}]
+
+    # merge in baseline values, if present
+    if "baseline_parameters" in griddle:
+        param_sets = [ps | griddle["baseline_parameters"] for ps in param_sets]
+
+    # find where nested values will get merged, if they are present
+    if "nested_parameters" in griddle:
+        for nest in griddle["nested_parameters"]:
+            m = _match_nest(nest, param_sets)
+            if m is None:
+                raise RuntimeError(
+                    f"Nest {nest} does not match any parameter set in {param_sets}"
+                )
+            else:
+                param_sets[m] |= nest
+
+    # update the nested values, if nests were present
+    for ps_i, nest in ps_nest_map.items():
+        if ps_i is None:
+            raise RuntimeError(
+                f"Nest {nest} does not match any parameter set in {param_sets}"
+            )
+        else:
+            param_sets[ps_i] |= nest
+
+    return Experiment([Spec(ps) for ps in param_sets])
+
+
+def _match_nest(nest: dict, param_sets: Iterable[dict]) -> int | None:
+    """Which parameter set does this nest match to?"""
+    matches = [_match_nest1(nest, ps) for ps in param_sets]
+    n_matches = matches.count(True)
+    if n_matches == 0:
+        return None
+    elif n_matches == 1:
+        return matches.index(True)
+    else:
+        raise RuntimeError(f"Nest {nest} matches multiple of {param_sets}")
+
+
+def _match_nest1(nest: dict, param_set: dict) -> bool:
+    """Does this nest match this parameter set?"""
+    common_keys = nest.keys() & param_set.keys()
+    nest_subset = {key: nest[key] for key in common_keys}
+    param_subset = {key: param_set[key] for key in common_keys}
+    return nest_subset == param_subset

--- a/tests/test_griddle_v01.py
+++ b/tests/test_griddle_v01.py
@@ -1,0 +1,53 @@
+import yaml
+
+from griddler import parse
+from griddler.schemas.v01 import _match_nest
+
+
+def test_grid_only():
+    griddle = yaml.safe_load("""
+    schema: v0.1
+    grid_parameters:
+      R0: [1.0, 2.0]
+      gamma: [1.0, 2.0]
+    """)
+    assert parse(griddle).to_dicts() == [
+        {"R0": 1.0, "gamma": 1.0},
+        {"R0": 1.0, "gamma": 2.0},
+        {"R0": 2.0, "gamma": 1.0},
+        {"R0": 2.0, "gamma": 2.0},
+    ]
+
+
+def test_match_nest():
+    assert (
+        _match_nest(
+            nest={"scenario": "optimistic", "R0": 0.5},
+            param_sets=[{"scenario": "optimistic"}, {"scenario": "pessimistic"}],
+        )
+        == 0
+    )
+
+
+def test_baseline_grid_nested():
+    griddle = yaml.safe_load("""
+    schema: v0.1
+
+    baseline_parameters:
+      R0: 1.0
+
+    grid_parameters:
+      scenario: [baseline, optimistic, pessimistic]
+
+    nested_parameters:
+      - scenario: optimistic
+        R0: 0.5
+      - scenario: pessimistic
+        R0: 2.0
+    """)
+
+    assert parse(griddle).to_dicts() == [
+        {"scenario": "baseline", "R0": 1.0},
+        {"scenario": "optimistic", "R0": 0.5},
+        {"scenario": "pessimistic", "R0": 2.0},
+    ]


### PR DESCRIPTION
For now, I'm calling the original schema, with its "baseline", "grid", and "nest", as "v0.1".

This and v0.3 would both benefit strongly from an intersection operation between an Experiment $X$ and a Spec $s$:

```math
X \cap s = \{ x \in X : s_i = 0_M \text{ or } x_i = s_i \forall i \}
```

that is, get all the constituent Specs in $X$ that match the (assigned) values in $s$. With this operation, the v0.3 "add parameter $p$ if condition $c$" thing (where $p$ and $c$ are just single-parameter Specs) would turn into:

```math
[(X \cap s) \otimes \{ p \}] \cup (X \cap s)^C
```

Similarly, the "nests" in v0.1 could be turned into a similar kind of intersection.