### PR TITLE
Handle empty union and product in v0.4 parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- v0.4 parser no longer raises an opaque `TypeError` on an empty `union` or `product`. An empty union now yields the empty experiment and an empty product yields a single empty spec, matching each operator's identity.
+
 ## 0.4.0
 
 ### Added

--- a/griddler/schemas/v04/__init__.py
+++ b/griddler/schemas/v04/__init__.py
@@ -39,9 +39,13 @@ def _parse_experiment(x: list[dict[str, Any]] | dict[str, Any]) -> Experiment:
         assert isinstance(value, list)
         subexperiments = [_parse_experiment(elt) for elt in value]
         if key == "union":
-            return functools.reduce(lambda x, y: x | y, subexperiments)
+            # empty union is the empty experiment (identity for union)
+            return functools.reduce(lambda x, y: x | y, subexperiments, Experiment([]))
         elif key == "product":
-            return functools.reduce(lambda x, y: x * y, subexperiments)
+            # empty product is a single empty spec (identity for product)
+            return functools.reduce(
+                lambda x, y: x * y, subexperiments, Experiment([{}])
+            )
         else:
             raise RuntimeError(f"Unknown experiment key: {key}")
     else:

--- a/tests/griddle/test_v04.py
+++ b/tests/griddle/test_v04.py
@@ -56,6 +56,14 @@ class TestParse:
             {"R0": 2.5, "gamma": 2.0},
         ]
 
+    def test_empty_union(self):
+        # an empty union is the identity for union: the empty experiment
+        assert self.parse_experiment({"union": []}) == []
+
+    def test_empty_product(self):
+        # an empty product is the identity for product: a single empty spec
+        assert self.parse_experiment({"product": []}) == [{}]
+
     def test_nested1(self):
         expt = {
             "product": [


### PR DESCRIPTION
The v0.4 schema accepts an empty `union` or `product` array (neither has a `minItems` constraint), but parsing one currently crashes.

`_parse_experiment` folds the subexperiments with `functools.reduce` and no initializer, so an empty list raises `TypeError: reduce() of empty iterable with no initial value` rather than a defined result or a clear error.

This passes the identity element for each operator: the empty experiment for union and a single empty spec for product. Both are true identities, so non-empty inputs are unchanged. This also lines up the empty cases with the existing minimal ones, where `experiment: []` gives `[]` and `experiment: [{}]` gives `[{}]`.

Verification: added `test_empty_union` and `test_empty_product`, which fail on `main` with the TypeError above and pass with the change. Full suite is 32 passing locally, and ruff check/format are clean.

For context, I work on supply-chain security and reproducibility in scientific tooling, which is how I ran into the empty-fold edge case.